### PR TITLE
Fix cache rule for "any"

### DIFF
--- a/deploy/1861/etc/nginx/proxy.conf
+++ b/deploy/1861/etc/nginx/proxy.conf
@@ -6,7 +6,26 @@
 ##
 
 proxy_temp_path     /data/nginx/temp;
-proxy_cache_path    /data/nginx/cache keys_zone=CACHE:10m levels=1:2 inactive=6h max_size=1g use_temp_path=off;
+proxy_cache_path    /data/nginx/cache keys_zone=CACHE:10m levels=1:2 inactive=6h max_size=1g use_temp_path=off purger=on;
+
+##
+# map for purge method and key
+# proxy_cache_key $uri;
+# proxy_cache_purge $purge_method;
+# server {
+#     ...
+#     location / {
+#         proxy_pass http://backend;
+#         proxy_cache cache_zone;
+#         proxy_cache_key $uri;
+#         proxy_cache_purge $purge_method;
+#     }
+# }
+##
+map $request_method $purge_method {
+    PURGE 1;
+    default 0;
+}
 
 ## header helpers for reverse proxied servers
 ## added $proxy_port so port of proxied request is exposed to eXist-db

--- a/deploy/1861/etc/nginx/vhosts/1861.hsg.conf
+++ b/deploy/1861/etc/nginx/vhosts/1861.hsg.conf
@@ -27,6 +27,8 @@ server {
         proxy_cache             CACHE;
         proxy_cache_revalidate  on;
         proxy_cache_valid       200 302 10m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
         proxy_cache_lock        on;
@@ -52,17 +54,23 @@ server {
     }
 
     location /historicaldocuments/.*/index {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
     location /departmenthistory/people/by-year/.* {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
     location /historicaldocuments/.*/persons {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 

--- a/deploy/1861/etc/nginx/vhosts/1861.hsg.conf
+++ b/deploy/1861/etc/nginx/vhosts/1861.hsg.conf
@@ -29,6 +29,7 @@ server {
         proxy_cache_valid       200 302 10m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock        on;
         expires                 5m;
         add_header              X-Proxy-Cache $upstream_cache_status;
         add_header              Strict-Transport-Security "max-age=31557600; includeSubdomains" always; # 1 year

--- a/deploy/1861/etc/nginx/vhosts/1861.hsg.conf
+++ b/deploy/1861/etc/nginx/vhosts/1861.hsg.conf
@@ -16,6 +16,9 @@ server {
     include                     ssl/1861.hsg.ssl.conf;
     include                     ssl/ssl.conf;
 
+    ## Force the latest IE version
+    add_header                  "X-UA-Compatible" "IE=Edge";
+
     location / {
         proxy_pass              https://backend/exist/apps/hsg-shell/;
         proxy_ignore_headers    Set-Cookie Expires;
@@ -34,6 +37,7 @@ server {
         proxy_cache_lock        on;
         expires                 5m;
         add_header              X-Proxy-Cache $upstream_cache_status;
+        add_header              "X-UA-Compatible" "IE=Edge";
         add_header              Strict-Transport-Security "max-age=31557600; includeSubdomains" always; # 1 year
         proxy_set_header        nginx-request-uri   $request_uri;
         proxy_cache_bypass      $http_cachepurge;

--- a/deploy/1861/etc/nginx/vhosts/hsg.conf
+++ b/deploy/1861/etc/nginx/vhosts/hsg.conf
@@ -9,9 +9,7 @@ server {
 
     charset                     utf-8;
 
-    #server_name                    52.200.115.76 *.history.state.gov;
     server_name                 history.state.gov *.history.state.gov;
-    #return                     301 https://52.200.115.76$request_uri;
 
     location / {
         return                  301 https://history.state.gov$request_uri;
@@ -61,7 +59,6 @@ server {
     listen                      443 ssl;
     listen                      [::]:443 ssl;
 
-    #server_name                    52.200.115.76 *.history.state.gov;
     server_name                 history.state.gov;
 
     charset                     utf-8;

--- a/deploy/1861/etc/nginx/vhosts/hsg.conf
+++ b/deploy/1861/etc/nginx/vhosts/hsg.conf
@@ -83,6 +83,7 @@ server {
         proxy_cache             CACHE;
         proxy_cache_revalidate  on;
         proxy_cache_valid       200 302 10m;
+        proxy_cache_valid       401 0m;
         proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
@@ -102,17 +103,23 @@ server {
     }
 
     location /historicaldocuments/.*/index {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
     location /departmenthistory/people/by-year/.* {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
     location /historicaldocuments/.*/persons {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
@@ -158,6 +165,7 @@ server {
         proxy_cache             CACHE;
         proxy_cache_revalidate  on;
         proxy_cache_valid       200 302 10m;
+        proxy_cache_valid       401 0m;
         proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;

--- a/deploy/1861/etc/nginx/vhosts/hsg.conf
+++ b/deploy/1861/etc/nginx/vhosts/hsg.conf
@@ -86,6 +86,7 @@ server {
         proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock        on;
         expires                 5m;
         add_header              X-Proxy-Cache $upstream_cache_status;
         add_header              "X-UA-Compatible" "IE=Edge";
@@ -160,6 +161,7 @@ server {
         proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock        on;
         expires                 5m;
         add_header              X-Proxy-Cache $upstream_cache_status;
         add_header              "X-UA-Compatible" "IE=Edge";

--- a/deploy/1991/etc/nginx/proxy.conf
+++ b/deploy/1991/etc/nginx/proxy.conf
@@ -6,7 +6,26 @@
 ##
 
 proxy_temp_path     /data/nginx/temp;
-proxy_cache_path    /data/nginx/cache keys_zone=CACHE:10m levels=1:2 inactive=6h max_size=1g use_temp_path=off;
+proxy_cache_path    /data/nginx/cache keys_zone=CACHE:10m levels=1:2 inactive=6h max_size=1g use_temp_path=off purger=on;
+
+##
+# map for purge method and key
+# proxy_cache_key $uri;
+# proxy_cache_purge $purge_method;
+# server {
+#     ...
+#     location / {
+#         proxy_pass http://backend;
+#         proxy_cache cache_zone;
+#         proxy_cache_key $uri;
+#         proxy_cache_purge $purge_method;
+#     }
+# }
+##
+map $request_method $purge_method {
+    PURGE 1;
+    default 0;
+}
 
 ## header helpers for reverse proxied servers
 ## added $proxy_port so port of proxied request is exposed to eXist-db

--- a/deploy/1991/etc/nginx/vhosts/1991.hsg.conf
+++ b/deploy/1991/etc/nginx/vhosts/1991.hsg.conf
@@ -27,6 +27,8 @@ server {
         proxy_cache             CACHE;
         proxy_cache_revalidate  on;
         proxy_cache_valid       200 302 10m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
         proxy_cache_lock        on;
@@ -52,17 +54,23 @@ server {
     }
 
     location /historicaldocuments/.*/index {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
     location /departmenthistory/people/by-year/.* {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
     location /historicaldocuments/.*/persons {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 

--- a/deploy/1991/etc/nginx/vhosts/1991.hsg.conf
+++ b/deploy/1991/etc/nginx/vhosts/1991.hsg.conf
@@ -29,6 +29,7 @@ server {
         proxy_cache_valid       200 302 10m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock        on;
         expires                 5m;
         add_header              X-Proxy-Cache $upstream_cache_status;
         add_header              Strict-Transport-Security "max-age=31557600; includeSubdomains" always; # 1 year

--- a/deploy/1991/etc/nginx/vhosts/1991.hsg.conf
+++ b/deploy/1991/etc/nginx/vhosts/1991.hsg.conf
@@ -16,6 +16,9 @@ server {
     include                     ssl/1991.hsg.ssl.conf;
     include                     ssl/ssl.conf;
 
+    ## Force the latest IE version
+    add_header                  "X-UA-Compatible" "IE=Edge";
+
     location / {
         proxy_pass              https://backend/exist/apps/hsg-shell/;
         proxy_ignore_headers    Set-Cookie Expires;
@@ -34,6 +37,7 @@ server {
         proxy_cache_lock        on;
         expires                 5m;
         add_header              X-Proxy-Cache $upstream_cache_status;
+        add_header              "X-UA-Compatible" "IE=Edge";
         add_header              Strict-Transport-Security "max-age=31557600; includeSubdomains" always; # 1 year
         proxy_set_header        nginx-request-uri   $request_uri;
         proxy_cache_bypass      $http_cachepurge;

--- a/deploy/1991/etc/nginx/vhosts/hsg.conf
+++ b/deploy/1991/etc/nginx/vhosts/hsg.conf
@@ -83,6 +83,7 @@ server {
         proxy_cache             CACHE;
         proxy_cache_revalidate  on;
         proxy_cache_valid       200 302 10m;
+        proxy_cache_valid       401 0m;
         proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
@@ -102,17 +103,23 @@ server {
     }
 
     location /historicaldocuments/.*/index {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
     location /departmenthistory/people/by-year/.* {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
     location /historicaldocuments/.*/persons {
-        proxy_cache_valid       any 60m;
+        proxy_cache_valid       200 302 60m;
+        proxy_cache_valid       401 0m;
+        proxy_cache_valid       any 5m;
         expires                 24h;
     }
 
@@ -158,6 +165,7 @@ server {
         proxy_cache             CACHE;
         proxy_cache_revalidate  on;
         proxy_cache_valid       200 302 10m;
+        proxy_cache_valid       401 0m;
         proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;

--- a/deploy/1991/etc/nginx/vhosts/hsg.conf
+++ b/deploy/1991/etc/nginx/vhosts/hsg.conf
@@ -86,6 +86,7 @@ server {
         proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock        on;
         expires                 5m;
         add_header              X-Proxy-Cache $upstream_cache_status;
         add_header              "X-UA-Compatible" "IE=Edge";
@@ -160,6 +161,7 @@ server {
         proxy_cache_valid       any 5m;
         proxy_cache_min_uses    1;
         proxy_cache_use_stale   error timeout invalid_header updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock        on;
         expires                 5m;
         add_header              X-Proxy-Cache $upstream_cache_status;
         add_header              "X-UA-Compatible" "IE=Edge";

--- a/deploy/1991/etc/nginx/vhosts/hsg.conf
+++ b/deploy/1991/etc/nginx/vhosts/hsg.conf
@@ -9,9 +9,7 @@ server {
 
     charset                     utf-8;
 
-    #server_name                    52.20.198.114 *.history.state.gov;
     server_name                 history.state.gov *.history.state.gov;
-    #return                     301 https://52.20.198.114$request_uri;
 
     location / {
         return                  301 https://history.state.gov$request_uri;
@@ -61,7 +59,6 @@ server {
     listen                      443 ssl;
     listen                      [::]:443 ssl;
 
-    #server_name                    52.20.198.114 *.history.state.gov;
     server_name                 history.state.gov;
 
     charset                     utf-8;


### PR DESCRIPTION
- adds a cache purge method
- sets caching rule more detailed
  - not just “any” for sub locations
  - puts a zero rule for 401 responses
- cleans server names and URIs
- takes on the IE rules for the sub domains

Extends #33 and #32