### PR TITLE
New setup & maintenance steps

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -679,6 +679,7 @@
         <delete dir="${eXist.data}/fs.journal"/>
         <delete dir="${eXist.data}/journal"/>
         <delete dir="${eXist.data}/lucene"/>
+        <delete dir="${eXist.data}/metadata"/>
         <delete dir="${eXist.data}/range"/>
         <delete dir="${eXist.data}/sanity"/>
         <delete>

--- a/build.xml
+++ b/build.xml
@@ -40,7 +40,7 @@
         <foreach-js property="remotes" target="git.clone"/>
     </target>
 
-    <target name="setup" depends="prepare,ivy.download,clone-public-repos,clone-private-repos"
+    <target name="setup" depends="prepare,ivy.setup,clone-public-repos,clone-private-repos"
         description="Clone required packages">
         <echo message="Completed cloning of packages..."/>
     </target>

--- a/build.xml
+++ b/build.xml
@@ -698,34 +698,56 @@
         <antcall target="wipe-exist-data"/>
     </target>
 
-    <target name="prepare-local-build-properties"
-        description="Create a local copy of build.properties and supply with needed information">
+    <target name="create-new-local-build-properties"
+        description="Create a new local copy of build.properties, overwriting any existing copy">
         <copy file="${build}/build.properties" tofile="${build}/local.build.properties" overwrite="yes"/>
+    </target>
+
+    <target name="check-local-build-properties"
+        description="Check to make sure a local copy of build.properties is available" unless="exists-local-build-properties">
+        <copy file="${build}/build.properties" tofile="${build}/local.build.properties"/>
+    </target>
+
+    <condition property="exists-local-build-properties">
+        <available file="${build}/local.build.properties"/>
+    </condition>
+    
+    <target name="upgrade-local-build-properties"
+        description="Upgrade local.build.properties file to latest build.properties while preserving passwords" depends="create-new-local-build-properties">
+        <echo message="------------------------------------------------------------"/>
+        <echo message="Upgrading local.build.properties file (preserving passwords)"/>
+        <echo message="------------------------------------------------------------"/>
+        <propertyfile file="${build}/local.build.properties" comment="customized hsg settings for this machine">
+            <entry key="eXist.data" value="${eXist.data}"/>
+            <entry key="eXist.home" value="${eXist.home}"/>
+            <entry key="git" value="${git}"/>
+            <entry key="github" value="${github}"/>
+            <entry key="local.instance.password" value="${local.instance.password}"/>
+            <entry key="production.instance.password" value="${production.instance.password}"/>
+        </propertyfile>
+    </target>
+    
+    <target name="store-production-password"
+        description="Store production password in local.build.properties" depends="check-local-build-properties">
         <property name="password" value="${password}"/>
-        <property name="include-private-repos" value="${include-private-repos}"/>
+        <propertyfile file="${build}/local.build.properties">
+            <entry key="production.instance.password" value="${password}"/>
+        </propertyfile>
+    </target>
+    
+    <target name="configure-for-exist-on-mac-system"
+        description="Configure hsg-project for use with eXist on a Mac system" depends="check-local-build-properties">
         <property name="user-home" value="${user-home}"/>
         <propertyfile file="${build}/local.build.properties" comment="hsg settings for ${user-home}">
-            <entry key="production.instance.password" value="${password}"/>
-            <entry key="remotes.include-private" value="${include-private-repos}"/>
-            <!--<entry operation="+" key="remotes" value=",${remotes.private}"/>-->
             <entry key="eXist.data" value="${user-home}${eXist.data.mac-dmg-installer}"/>
             <entry key="eXist.home" value="${eXist.home.mac-dmg-installer}"/>
         </propertyfile>
     </target>
 
-    <target name="prepare-production-build-properties"
-        description="Create a local copy of build.properties and supply with needed information">
-        <copy file="${build}/build.properties" tofile="${build}/local.build.properties" overwrite="yes"/>
-        <property name="password" value="${password}"/>
-        <propertyfile file="${build}/local.build.properties" comment="hsg settings for production">
-            <entry key="production.instance.password" value="${password}"/>
-            <!--<entry operation="+" key="remotes" value=",${remotes.private}"/>-->
-        </propertyfile>
-    </target>
-    
     <target name="prepare-hsg-project-for-upgrade-to-exist"
         description="Prepare hsg-project for the upgrade to the current version of eXist"
-        depends="wipe-exist-data-with-confirmation,delete-old-repos,regenerate-local-build-properties,prepare-exist-configuration,setup"/>
+        depends="wipe-exist-data-with-confirmation,delete-old-repos,upgrade-local-build-properties,prepare-exist-configuration,setup"/>
+    
     <target name="delete-old-repos" description="Delete cloned repositories used before upgrade to eXist 3.1.1">
         <echo message="------------------------------------------------------------------"/>
         <echo message="Deleting old repositories (eXide, shared-resources, tei-simple-pm)"/>
@@ -734,22 +756,7 @@
         <delete includeemptydirs="true" dir="${repos}/shared-resources"/>
         <delete includeemptydirs="true" dir="${repos}/tei-simple-pm"/>
     </target>
-    <target name="regenerate-local-build-properties"
-        description="Regenerate local.build.properties file while preserving passwords">
-        <echo message="---------------------------------------------------------------"/>
-        <echo message="Regenerating local.build.properties file (preserving passwords)"/>
-        <echo message="---------------------------------------------------------------"/>
-        <copy file="${build}/build.properties" tofile="${build}/local.build.properties"
-            overwrite="yes"/>
-        <propertyfile file="${build}/local.build.properties" comment="hsg settings for production">
-            <entry key="eXist.data" value="${eXist.data}"/>
-            <entry key="git" value="${git}"/>
-            <entry key="github" value="${github}"/>
-            <entry key="local.instance.password" value="${local.instance.password}"/>
-            <entry key="production.instance.password" value="${production.instance.password}"/>
-            <entry key="remotes.include-private" value="${remotes.include-private}"/>
-        </propertyfile>
-    </target>
+    
     <target name="prepare-exist-configuration" depends="back-up-exist-configuration-file">
         <echo message="-------------------------------------------------------"/>
         <echo message="Applying hsg customizations to eXist configuration file"/>

--- a/build.xml
+++ b/build.xml
@@ -722,7 +722,7 @@
         <echo message="------------------------------------------------------------"/>
         <echo message="Upgrading local.build.properties file (preserving passwords)"/>
         <echo message="------------------------------------------------------------"/>
-        <propertyfile file="${build}/local.build.properties" comment="customized hsg settings for this machine">
+        <propertyfile file="${build}/local.build.properties" comment="Updated with latest hsg-project settings">
             <entry key="eXist.data" value="${eXist.data}"/>
             <entry key="eXist.home" value="${eXist.home}"/>
             <entry key="git" value="${git}"/>
@@ -743,15 +743,15 @@
     <target name="configure-for-exist-on-mac-system"
         description="Configure hsg-project for use with eXist on a Mac system" depends="check-local-build-properties">
         <property name="user-home" value="${user-home}"/>
-        <propertyfile file="${build}/local.build.properties" comment="hsg settings for ${user-home}">
+        <propertyfile file="${build}/local.build.properties" comment="Updated to use eXist data and home locations, assuming macOS DMG installer, for ${user-home}">
             <entry key="eXist.data" value="${user-home}${eXist.data.mac-dmg-installer}"/>
             <entry key="eXist.home" value="${eXist.home.mac-dmg-installer}"/>
         </propertyfile>
     </target>
 
-    <target name="prepare-hsg-project-for-upgrade-to-exist"
-        description="Prepare hsg-project for the upgrade to the current version of eXist"
-        depends="wipe-exist-data-with-confirmation,delete-old-repos,upgrade-local-build-properties,prepare-exist-configuration,setup"/>
+    <target name="apply-hsg-project-customizations-to-exist"
+        description="Apply hsg-project customizations to eXist"
+        depends="upgrade-local-build-properties,prepare-exist-configuration"/>
     
     <target name="delete-old-repos" description="Delete cloned repositories used before upgrade to eXist 3.1.1">
         <echo message="------------------------------------------------------------------"/>

--- a/build.xml
+++ b/build.xml
@@ -670,6 +670,10 @@
         </condition>
         <fail if="${exist-running}"
             message="eXist is still running. Please shut down eXist and try again."/>
+        <condition property="eXist.data-exists">
+            <available file="${eXist.data}"/>
+        </condition>
+        <fail unless="${eXist.data-exists}" message="No eXist data was found in ${eXist.data}. This probably indicates you have just installed eXist. It could also indicate you have not run the steps required to prepare hsg-project's settings to find your eXist installation, so please consult the hsg-project setup documentation."/>
         <echo message="-------------------------"/>
         <echo message="Wiping eXist data"/>
         <echo message="-------------------------"/>

--- a/hsg-project.xpr
+++ b/hsg-project.xpr
@@ -99,7 +99,7 @@
                                     <String>(Divider)</String>
                                 </field>
                                 <field name="name">
-                                    <String>Get the latest data</String>
+                                    <String>= Get the latest data =</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>.</String>
@@ -131,7 +131,7 @@
                                     <String>Fetch updates for all repositories</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Fetch updates for all repositories</String>
+                                    <String>Fetch updates for all repositories</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -163,7 +163,7 @@
                                     <String>Fetch updates for the parent repository of the working file in the active tab to eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Fetch updates for current repository</String>
+                                    <String>Fetch updates for current repository</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -195,7 +195,7 @@
                                     <String>(Divider)</String>
                                 </field>
                                 <field name="name">
-                                    <String>Preview on localhost</String>
+                                    <String>= Preview on localhost =</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>.</String>
@@ -227,7 +227,7 @@
                                     <String>Delete the working file in the active tab from eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Delete current file from localhost</String>
+                                    <String>Delete current file from localhost</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -259,7 +259,7 @@
                                     <String>Build and deploy the parent repository of the working file in the active tab to eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Deploy current repository to localhost</String>
+                                    <String>Deploy current repository to localhost</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -291,7 +291,7 @@
                                     <String>Upload the working file in the active tab to eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Upload current file to localhost</String>
+                                    <String>Upload current file to localhost</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -323,7 +323,7 @@
                                     <String>(Divider)</String>
                                 </field>
                                 <field name="name">
-                                    <String>Publish to history.state.gov</String>
+                                    <String>= Publish to history.state.gov =</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>.</String>
@@ -355,7 +355,7 @@
                                     <String>Delete the working file in the active tab from eXist-db on history.state.gov</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Delete current file from history.state.gov</String>
+                                    <String>Delete current file from history.state.gov</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -387,7 +387,7 @@
                                     <String>Upload the working file in the active tab to eXist-db on history.state.gov</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Upload current file to history.state.gov</String>
+                                    <String>Upload current file to history.state.gov</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -419,7 +419,7 @@
                                     <String>(Divider)</String>
                                 </field>
                                 <field name="name">
-                                    <String>First time setup</String>
+                                    <String>= Setup and maintenance =</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>.</String>
@@ -445,13 +445,13 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" setup</String>
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" delete-old-repos setup</String>
                                 </field>
                                 <field name="description">
                                     <String>Clone all repositories</String>
                                 </field>
                                 <field name="name">
-                                    <String>    1. Clone all repositories</String>
+                                    <String>1. Clone all repositories</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -477,16 +477,16 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
-                                    <String></String>
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" configure-for-exist-on-mac-system -Duser-home=${homeDir}</String>
                                 </field>
                                 <field name="description">
-                                    <String>Configure hsg-project for use with current macOS and eXist installed via dmg installer</String>
+                                    <String>Configure hsg-project for use with current macOS and eXist installed via dmg installer </String>
                                 </field>
                                 <field name="name">
-                                    <String>    2. Apply Mac settings to hsg-project</String>
+                                    <String>2. Apply Mac settings to hsg-project</String>
                                 </field>
                                 <field name="workingDirectory">
-                                    <String>.</String>
+                                    <String>${pd}</String>
                                 </field>
                                 <field name="keyStroke">
                                     <null/>
@@ -509,13 +509,45 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
-                                    <String>sh "${oxygenInstallDir}/tools/ant/bin/ant"</String>
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" apply-hsg-project-customizations-to-exist</String>
+                                </field>
+                                <field name="description">
+                                    <String>Configure hsg-project's modules, jobs in eXist</String>
+                                </field>
+                                <field name="name">
+                                    <String>3. Apply hsg-project settings to eXist</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>${pd}</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar"</String>
                                 </field>
                                 <field name="description">
                                     <String>Build and deploy all repositories to eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>    3. Deploy all repositories to localhost</String>
+                                    <String>4. Deploy all repositories to localhost</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -541,77 +573,13 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" enter-production-server-credentials -Dpassword="${ask('Please enter the password for 1861.history.state.gov', password)}"</String>
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" store-production-password -Dpassword="${ask('Please enter the password for 1861.history.state.gov', password)}"</String>
                                 </field>
                                 <field name="description">
                                     <String>Enter production server credentials</String>
                                 </field>
                                 <field name="name">
-                                    <String>    4. Enter production server credentials</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>${pd}</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <null/>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>true</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <String>text/plain</String>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>echo "Sorry this isn't a command!"</String>
-                                </field>
-                                <field name="description">
-                                    <String>(Divider)</String>
-                                </field>
-                                <field name="name">
-                                    <String>Maintenance</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>.</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <null/>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>true</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <String>text/plain</String>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" prepare-hsg-project-for-upgrade-to-exist -Dare-you-sure="${ask('This operation deletes your local eXist database. Any work not saved to the repositories will be lost. Are you sure?', radio, ('true':'Yes';'false':'No'), 'No')}" </String>
-                                </field>
-                                <field name="description">
-                                    <String>Prepare hsg-project for upgrade to latest eXist</String>
-                                </field>
-                                <field name="name">
-                                    <String>    Prepare for upgrade to latest eXist</String>
+                                    <String>5. Enter production server credentials</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -643,7 +611,7 @@
                                     <String>Wipe eXist database (in preparation for a fresh start)</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Wipe eXist database</String>
+                                    <String>Wipe eXist database</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -672,10 +640,10 @@
                                     <String>echo "Sorry this isn't a command!"</String>
                                 </field>
                                 <field name="description">
-                                    <String>Divider</String>
+                                    <String>(Divider)</String>
                                 </field>
                                 <field name="name">
-                                    <String>Integration with other applications</String>
+                                    <String>= Launch other applications =</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>.</String>
@@ -707,7 +675,7 @@
                                     <String>Open the parent repository of the working file in the active tab in Atom</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Open current repository in Atom</String>
+                                    <String>Open current repository in Atom</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -739,7 +707,7 @@
                                     <String>Open the parent repository of the working file in the active tab in GitHub Desktop</String>
                                 </field>
                                 <field name="name">
-                                    <String>    Open current repository in GitHub Desktop</String>
+                                    <String>Open current repository in GitHub Desktop</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>

--- a/hsg-project.xpr
+++ b/hsg-project.xpr
@@ -93,13 +93,45 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
+                                    <String>echo "Sorry this isn't a command!"</String>
+                                </field>
+                                <field name="description">
+                                    <String>(Divider)</String>
+                                </field>
+                                <field name="name">
+                                    <String>Get the latest data</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>.</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
                                     <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" update-hsg-project update</String>
                                 </field>
                                 <field name="description">
                                     <String>Fetch updates for all repositories</String>
                                 </field>
                                 <field name="name">
-                                    <String>Fetch updates for all repositories</String>
+                                    <String>    Fetch updates for all repositories</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -131,7 +163,7 @@
                                     <String>Fetch updates for the parent repository of the working file in the active tab to eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>Fetch updates for current repository</String>
+                                    <String>    Fetch updates for current repository</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -157,80 +189,16 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" open-repo-in-github-desktop -Ddirectory="${cfd}"</String>
+                                    <String>echo "Sorry this isn't a command!"</String>
                                 </field>
                                 <field name="description">
-                                    <String>Open the parent repository of the working file in the active tab in GitHub Desktop</String>
+                                    <String>(Divider)</String>
                                 </field>
                                 <field name="name">
-                                    <String>Open current repository in GitHub Desktop</String>
+                                    <String>Preview on localhost</String>
                                 </field>
                                 <field name="workingDirectory">
-                                    <String>${pd}</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <null/>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>true</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <String>text/plain</String>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" upload-file-to-localhost -Ddirectory="${cfd}" -Dfile-name="${cfne}"</String>
-                                </field>
-                                <field name="description">
-                                    <String>Upload the working file in the active tab to eXist-db on localhost</String>
-                                </field>
-                                <field name="name">
-                                    <String>Upload current file to localhost</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>${pd}</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <String>M1 U</String>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>true</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <String>text/plain</String>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" upload-file-to-production -Ddirectory="${cfd}" -Dfile-name="${cfne}"</String>
-                                </field>
-                                <field name="description">
-                                    <String>Upload the working file in the active tab to eXist-db on history.state.gov</String>
-                                </field>
-                                <field name="name">
-                                    <String>Upload current file to history.state.gov</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>${pd}</String>
+                                    <String>.</String>
                                 </field>
                                 <field name="keyStroke">
                                     <null/>
@@ -259,167 +227,7 @@
                                     <String>Delete the working file in the active tab from eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>Delete current file from localhost</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>${pd}</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <null/>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>true</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <String>text/plain</String>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" delete-file-from-production -Ddirectory="${cfd}" -Dfile-name="${cfne}"</String>
-                                </field>
-                                <field name="description">
-                                    <String>Delete the working file in the active tab from eXist-db on history.state.gov</String>
-                                </field>
-                                <field name="name">
-                                    <String>Delete current file from history.state.gov</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>${pd}</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <null/>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>true</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <null/>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>echo "Sorry this isn't a command!"</String>
-                                </field>
-                                <field name="description">
-                                    <String>(Divider)</String>
-                                </field>
-                                <field name="name">
-                                    <String>---</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>.</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <null/>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>false</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <String>text/plain</String>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" prepare-local-build-properties -Dpassword="${ask('Please enter the password for 1861.history.state.gov', password)}" -Dinclude-private-repositories="${ask('Include private repositories?', radio, ('true':'Yes';'false':'No'), 'No')}" -Duser-home="${homeDir}"</String>
-                                </field>
-                                <field name="description">
-                                    <String>Enter server credentials</String>
-                                </field>
-                                <field name="name">
-                                    <String>Enter server credentials</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>${pd}</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <null/>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>true</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <String>text/plain</String>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" setup</String>
-                                </field>
-                                <field name="description">
-                                    <String>Clone all repositories</String>
-                                </field>
-                                <field name="name">
-                                    <String>Clone all repositories</String>
-                                </field>
-                                <field name="workingDirectory">
-                                    <String>${pd}</String>
-                                </field>
-                                <field name="keyStroke">
-                                    <null/>
-                                </field>
-                                <field name="isBuiltin">
-                                    <Boolean>false</Boolean>
-                                </field>
-                                <field name="showConsole">
-                                    <Boolean>true</Boolean>
-                                </field>
-                            </xsltCustomEngines>
-                            <xsltCustomEngines>
-                                <field name="outEncoding">
-                                    <null/>
-                                </field>
-                                <field name="outContentType">
-                                    <String>text/plain</String>
-                                </field>
-                                <field name="errEncoding">
-                                    <null/>
-                                </field>
-                                <field name="cmd">
-                                    <String>sh "${oxygenInstallDir}/tools/ant/bin/ant"</String>
-                                </field>
-                                <field name="description">
-                                    <String>Build and deploy all repositories to eXist-db on localhost</String>
-                                </field>
-                                <field name="name">
-                                    <String>Deploy all repositories to localhost</String>
+                                    <String>    Delete current file from localhost</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -451,7 +259,7 @@
                                     <String>Build and deploy the parent repository of the working file in the active tab to eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>Deploy current repository to localhost</String>
+                                    <String>    Deploy current repository to localhost</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -477,13 +285,77 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" open-repo-in-atom -Ddirectory="${cfd}"</String>
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" upload-file-to-localhost -Ddirectory="${cfd}" -Dfile-name="${cfne}"</String>
                                 </field>
                                 <field name="description">
-                                    <String>Open the parent repository of the working file in the active tab in Atom</String>
+                                    <String>Upload the working file in the active tab to eXist-db on localhost</String>
                                 </field>
                                 <field name="name">
-                                    <String>Open current repository in Atom</String>
+                                    <String>    Upload current file to localhost</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>${pd}</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <String>M1 U</String>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>echo "Sorry this isn't a command!"</String>
+                                </field>
+                                <field name="description">
+                                    <String>(Divider)</String>
+                                </field>
+                                <field name="name">
+                                    <String>Publish to history.state.gov</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>.</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" delete-file-from-production -Ddirectory="${cfd}" -Dfile-name="${cfne}"</String>
+                                </field>
+                                <field name="description">
+                                    <String>Delete the working file in the active tab from eXist-db on history.state.gov</String>
+                                </field>
+                                <field name="name">
+                                    <String>    Delete current file from history.state.gov</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -509,13 +381,237 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" clean</String>
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" upload-file-to-production -Ddirectory="${cfd}" -Dfile-name="${cfne}"</String>
                                 </field>
                                 <field name="description">
-                                    <String>Delete generated packages</String>
+                                    <String>Upload the working file in the active tab to eXist-db on history.state.gov</String>
                                 </field>
                                 <field name="name">
-                                    <String>Delete generated packages</String>
+                                    <String>    Upload current file to history.state.gov</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>${pd}</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <null/>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>echo "Sorry this isn't a command!"</String>
+                                </field>
+                                <field name="description">
+                                    <String>(Divider)</String>
+                                </field>
+                                <field name="name">
+                                    <String>First time setup</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>.</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>false</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" setup</String>
+                                </field>
+                                <field name="description">
+                                    <String>Clone all repositories</String>
+                                </field>
+                                <field name="name">
+                                    <String>    1. Clone all repositories</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>${pd}</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String></String>
+                                </field>
+                                <field name="description">
+                                    <String>Configure hsg-project for use with current macOS and eXist installed via dmg installer</String>
+                                </field>
+                                <field name="name">
+                                    <String>    2. Apply Mac settings to hsg-project</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>.</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>sh "${oxygenInstallDir}/tools/ant/bin/ant"</String>
+                                </field>
+                                <field name="description">
+                                    <String>Build and deploy all repositories to eXist-db on localhost</String>
+                                </field>
+                                <field name="name">
+                                    <String>    3. Deploy all repositories to localhost</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>${pd}</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" enter-production-server-credentials -Dpassword="${ask('Please enter the password for 1861.history.state.gov', password)}"</String>
+                                </field>
+                                <field name="description">
+                                    <String>Enter production server credentials</String>
+                                </field>
+                                <field name="name">
+                                    <String>    4. Enter production server credentials</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>${pd}</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>echo "Sorry this isn't a command!"</String>
+                                </field>
+                                <field name="description">
+                                    <String>(Divider)</String>
+                                </field>
+                                <field name="name">
+                                    <String>Maintenance</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>.</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" prepare-hsg-project-for-upgrade-to-exist -Dare-you-sure="${ask('This operation deletes your local eXist database. Any work not saved to the repositories will be lost. Are you sure?', radio, ('true':'Yes';'false':'No'), 'No')}" </String>
+                                </field>
+                                <field name="description">
+                                    <String>Prepare hsg-project for upgrade to latest eXist</String>
+                                </field>
+                                <field name="name">
+                                    <String>    Prepare for upgrade to latest eXist</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -547,7 +643,7 @@
                                     <String>Wipe eXist database (in preparation for a fresh start)</String>
                                 </field>
                                 <field name="name">
-                                    <String>Wipe eXist database</String>
+                                    <String>    Wipe eXist database</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>
@@ -573,13 +669,77 @@
                                     <null/>
                                 </field>
                                 <field name="cmd">
-                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" prepare-hsg-project-for-upgrade-to-exist -Dare-you-sure="${ask('This operation deletes your local eXist database. Any work not saved to the repositories will be lost. Are you sure?', radio, ('true':'Yes';'false':'No'), 'No')}" </String>
+                                    <String>echo "Sorry this isn't a command!"</String>
                                 </field>
                                 <field name="description">
-                                    <String>Prepare hsg-project for upgrade to latest eXist</String>
+                                    <String>Divider</String>
                                 </field>
                                 <field name="name">
-                                    <String>Prepare for upgrade to latest eXist</String>
+                                    <String>Integration with other applications</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>.</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" open-repo-in-atom -Ddirectory="${cfd}"</String>
+                                </field>
+                                <field name="description">
+                                    <String>Open the parent repository of the working file in the active tab in Atom</String>
+                                </field>
+                                <field name="name">
+                                    <String>    Open current repository in Atom</String>
+                                </field>
+                                <field name="workingDirectory">
+                                    <String>${pd}</String>
+                                </field>
+                                <field name="keyStroke">
+                                    <null/>
+                                </field>
+                                <field name="isBuiltin">
+                                    <Boolean>false</Boolean>
+                                </field>
+                                <field name="showConsole">
+                                    <Boolean>true</Boolean>
+                                </field>
+                            </xsltCustomEngines>
+                            <xsltCustomEngines>
+                                <field name="outEncoding">
+                                    <null/>
+                                </field>
+                                <field name="outContentType">
+                                    <String>text/plain</String>
+                                </field>
+                                <field name="errEncoding">
+                                    <null/>
+                                </field>
+                                <field name="cmd">
+                                    <String>java -Dlog4j.configurationFile="${pd}/build/log4j2.xml" -jar "${oxygenInstallDir}/tools/ant/lib/ant-launcher.jar" open-repo-in-github-desktop -Ddirectory="${cfd}"</String>
+                                </field>
+                                <field name="description">
+                                    <String>Open the parent repository of the working file in the active tab in GitHub Desktop</String>
+                                </field>
+                                <field name="name">
+                                    <String>    Open current repository in GitHub Desktop</String>
                                 </field>
                                 <field name="workingDirectory">
                                     <String>${pd}</String>


### PR DESCRIPTION
**Important: Because of significant changes introduced recently, all @HistoryAtState/editors who use hsg-project on their DIN/home machines will need to perform all of the steps listed under https://github.com/HistoryAtState/hsg-project/wiki/Setup#updating-from-an-old-setup, even if you've done some of these steps recently. It is especially important that you perform all of these steps if you preview hsg content on your machine with eXist, so that you avoid errors. Please contact me if you have any questions or problems as you proceed.**

I have revised the hsg-project.xpr file and its corresponding scripts (in build.xml) to simplify the steps needed for getting set up and for performing maintenance on our systems. I've also restructured our entries in the External Tools menu. 

This change was prompted by our new search engine's use of an eXist module that is not enabled by default. In order to allow everyone's systems to work with this new code, I had to introduce a new External Tools menu entry, "Apply hsg-project settings to eXist".

As long as I was doing this, I also took the opportunity to reorganize the menus and separate/realign some of the setup and maintenance scripts to make them more useful for first time users and for users who need to perform maintenance or troubleshooting. A summary of the changes:

- Now menus are grouped into sections: (1) Get the latest data (2) Preview on localhost (3) Publish to history.state.gov (4) Setup & maintenance (5) Launch other applications.
- Setup & maintenance section now has numbered commands to help ensure setup steps are performed in order, corresponding to setup order in the hsg-project wiki: (1) Clone all repositories (2) Apply Mac settings to hsg-project (3) Apply hsg-project settings to eXist (4) Deploy all repositories to localhost (5) Enter production server credentials. Wipe eXist data is placed there, but is unnumbered, since it is a maintenance step.
- These setup & maintenance steps can also be used to help during upgrades. For example, if we make more changes to build.properties or conf.xml, we can instruct people to run steps 3 and 4. Re-running these doesn’t overwrite passwords.
- Now entering password (5) is separate from preparing local settings (3, 4). Before these functions were conflated, and people bumped into problems if they’d never entered server credentials.