### PR TITLE
Remove memsort module

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -183,11 +183,6 @@
             password="${local.instance.password}"
             query="repo:install-and-deploy('http://existsolutions.com/apps/tei-publisher-lib', '${eXist.public-repo.lookup}')"
         />
-        <echo message="Installing Memsort XQuery Module..."/>
-        <xdb:xquery uri="${local.instance.temp}" user="${local.instance.user}"
-            password="${local.instance.password}"
-            query="repo:install-and-deploy('http://exist-db.org/xquery/memsort', '${eXist.public-repo.lookup}')"
-        />
         <echo message="Installing Crypto Module..."/>
         <xdb:xquery uri="${local.instance.temp}" user="${local.instance.user}"
             password="${local.instance.password}"
@@ -222,11 +217,6 @@
             password="${production.instance.password}"
             query="repo:install-and-deploy('http://existsolutions.com/apps/tei-publisher-lib', '${eXist.public-repo.lookup}')"
         />
-        <echo message="Installing Memsort XQuery Module..."/>
-        <xdb:xquery uri="${production.instance.temp}" user="${production.instance.user}"
-            password="${production.instance.password}"
-            query="repo:install-and-deploy('http://exist-db.org/xquery/memsort', '${eXist.public-repo.lookup}')"
-        />
         <echo message="Installing Crypto Module..."/>
         <xdb:xquery uri="${local.instance.temp}" user="${local.instance.user}"
             password="${local.instance.password}"
@@ -260,11 +250,6 @@
         <xdb:xquery uri="${development.instance.temp}" user="${development.instance.user}"
             password="${development.instance.password}"
             query="repo:install-and-deploy('http://existsolutions.com/apps/tei-publisher-lib', '${eXist.public-repo.lookup}')"
-        />
-        <echo message="Installing Memsort XQuery Module..."/>
-        <xdb:xquery uri="${development.instance.temp}" user="${development.instance.user}"
-            password="${development.instance.password}"
-            query="repo:install-and-deploy('http://exist-db.org/xquery/memsort', '${eXist.public-repo.lookup}')"
         />
         <echo message="Installing Crypto Module..."/>
         <xdb:xquery uri="${development.instance.temp}" user="${development.instance.user}"

--- a/build/configure-exist.xsl
+++ b/build/configure-exist.xsl
@@ -21,22 +21,4 @@
         </xsl:copy>        
     </xsl:template>
 
-    <xsl:template match="scheduler">
-        <xsl:copy>
-            <xsl:apply-templates select="@* | node()"/>
-            <xsl:choose>
-                <xsl:when test="$target = 'production'">
-                    <xsl:comment>Jobs enabled for hsg production</xsl:comment>
-                    <job type="user" xquery="/db/apps/hsg-shell/modules/rebuild-dates-sort-index.xql" period="600000" unschedule-on-exception="false"/>
-                    <job xquery="/db/apps/twitter/jobs/download-recent-twitter-posts.xq" period="600000" unschedule-on-exception="false"/>
-                </xsl:when>
-                <xsl:when test="$target = 'development'">
-                    <xsl:comment>Jobs enabled for hsg development</xsl:comment>
-                    <job type="user" xquery="/db/apps/hsg-shell/modules/rebuild-dates-sort-index.xql" period="600000" unschedule-on-exception="false"/>
-                </xsl:when>
-                <xsl:otherwise/>
-            </xsl:choose>
-        </xsl:copy>        
-    </xsl:template>
-
 </xsl:stylesheet>


### PR DESCRIPTION
The memsort module will no longer be needed after hsg-shell switches to facets & fields

Related: https://github.com/HistoryAtState/hsg-shell/pull/382