### PR TITLE
Ant build improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ To automate the following steps:
 ## Prerequisites
 
 - eXist 5.x
-- Current versions of ant, git, and bower executables
+- Current versions of ant, ant-contrib, git, and bower executables
 
 ## Setup
 

--- a/build.xml
+++ b/build.xml
@@ -853,28 +853,28 @@
 
     <target name="ping-localhost">
         <condition property="exist-running">
-            <http requestmethod="HEAD" url="http://localhost:8080/exist" expected="200"/>
+            <http requestmethod="HEAD" url="http://localhost:8080/exist"/>
         </condition>
         <fail unless="${exist-running}" message="eXist is not running. Please start eXist and try again."/>
     </target>
 
     <target name="ping-production">
         <condition property="exist-running">
-            <http requestmethod="GET" url="${production.instance.http}/test" expected="200"/>
+            <http requestmethod="GET" url="${production.instance.http}/test"/>
         </condition>
         <fail unless="${exist-running}" message="The production server cannot be reached. Please confirm you are connected to the internet and try again."/>
     </target>
 
     <target name="ping-dev-server">
         <condition property="exist-running">
-            <http requestmethod="GET" url="${development.instance.http}" expected="200"/>
+            <http requestmethod="GET" url="${development.instance.http}"/>
         </condition>
         <fail unless="${exist-running}" message="The development server cannot be reached. Please confirm you are connected to the internet and try again."/>
     </target>
     
     <target name="ping-public-repo">
         <condition property="public-repo-accessible">
-            <http requestmethod="HEAD" url="${eXist.public-repo.lookup}?abbrev=functx" followRedirects="true" expected="200"/>
+            <http requestmethod="HEAD" url="${eXist.public-repo.lookup}?abbrev=functx" followRedirects="true"/>
         </condition>
         <fail unless="${public-repo-accessible}" message="The package repository at ${eXist.public-repo} cannot be reached. Please confirm you are connected to the internet and try again."/>
     </target>
@@ -884,7 +884,7 @@
     <!-- =================================================================== -->
     <target name="wipe-exist-data" description="Wipe eXist data">
         <condition property="exist-running">
-            <http requestmethod="GET" url="http://localhost:8080/exist" expected="200"/>
+            <http requestmethod="GET" url="http://localhost:8080/exist"/>
         </condition>
         <fail if="${exist-running}"
             message="eXist is still running. Please shut down eXist and try again."/>

--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project basedir="." name="HsgProject" default="all" xmlns:xdb="http://exist-db.org/ant">
+<project basedir="." name="HsgProject" default="all" xmlns:if="ant:if" xmlns:unless="ant:unless" xmlns:xdb="http://exist-db.org/ant">
     <property file="build/local.build.properties"/>
     <property file="build/build.properties"/>
 
@@ -27,20 +27,36 @@
     <target name="all" depends="ping-localhost,ping-public-repo,clean,update,build,deploy"
         description="Clean, update, build, and deploy all packages (assumes 'setup' has already been run)"/>
 
-    <condition property="remotes.include-private">
-        <istrue value="${remotes.include-private}"/>
+    <condition property="git.private.include">
+        <istrue value="${git.private.include}"/>
     </condition>
 
-    <target name="clone-private-repos" if="${remotes.include-private}"
+    <target name="clone-private-repos" if="${git.private.include}"
         description="Clone private packages">
         <echo message="Cloning private packages into ${repos}..."/>
-        <foreach list="${remotes.private}" delimiter="," parallel="true" target="git.clone" param="remote"/>
+        <foreach list="${git.private.repo-names}" delimiter="," parallel="true" target="git.clone.private" param="repo-name"/>
+    </target>
+
+    <target name="git.clone.private">
+        <antcall target="git.clone">
+            <param name="local-repo-name" value="${repo-name}"/>
+            <param name="origin" value="${git.private.remotes.origin.org}/${repo-name}.git"/>
+            <param name="upstream" value="${git.private.remotes.upstream.org}/${repo-name}.git"/>
+        </antcall>
     </target>
 
     <target name="clone-public-repos">
         <echo message="Cloning required packages into ${repos}..."
             description="Clone public packages"/>
-        <foreach list="${remotes}" delimiter="," parallel="true" target="git.clone" param="remote"/>
+        <foreach list="${git.public.repo-names}" delimiter="," parallel="true" target="git.clone.public" param="repo-name"/>
+    </target>
+
+    <target name="git.clone.public">
+        <antcall target="git.clone">
+            <param name="local-repo-name" value="${repo-name}"/>
+            <param name="origin" value="${git.public.remotes.origin.org}/${repo-name}.git"/>
+            <param name="upstream" value="${git.public.remotes.upstream.org}/${repo-name}.git"/>
+        </antcall>
     </target>
 
     <target name="setup" depends="prepare,mvn-copy-dependencies,upgrade-local-build-properties,clone-public-repos,clone-private-repos"
@@ -463,13 +479,33 @@
     </scriptdef>
 
     <target name="git.clone">
-        <echo message="Cloning ${remote}..."/>
-        <exec executable="${git}" outputproperty="git.output" dir="${repos}">
+        <echo message="Cloning ${origin}..."/>
+        <exec executable="${git}" outputproperty="git.output" dir="${repos}" failonerror="true">
             <arg line="clone"/>
             <arg line="--depth"/>
             <arg line="1"/>
-            <arg line="${remote}"/>
+            <arg line="${origin}"/>
+            <arg line="${local-repo-name}"/>
         </exec>
+
+        <condition property="set-upstream">
+            <not>
+                <equals arg1="${origin}" arg2="${upstream}"/>
+            </not>
+        </condition>
+
+        <exec if:true="${set-upstream}" executable="${git}" dir="${repos}/${local-repo-name}" failonerror="true">
+            <arg line="remote"/>
+            <arg line="add"/>
+            <arg line="upstream"/>
+            <arg line="${upstream}"/>
+        </exec>
+
+        <exec if:true="${set-upstream}" executable="${git}" dir="${repos}/${local-repo-name}" failonerror="true">
+            <arg line="fetch"/>
+            <arg line="upstream"/>
+        </exec>
+
         <echo message="${git.output}"/>
     </target>
 
@@ -866,7 +902,7 @@
             <entry key="production.instance.password" value="${production.instance.password}"/>
             <entry key="development.instance.user" value="${development.instance.user}"/>
             <entry key="development.instance.password" value="${development.instance.password}"/>
-            <entry key="remotes.include-private" value="${remotes.include-private}"/>
+            <entry key="git.private.include" value="${git.private.include}"/>
         </propertyfile>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -22,6 +22,8 @@
     <property name="production.instance.temp" value="${production.instance.uri}${instance.tempPath}"/>
     <property name="development.instance.temp" value="${development.instance.uri}${instance.tempPath}"/>
 
+    <taskdef resource="net/sf/antcontrib/antcontrib.properties"/>
+
     <target name="all" depends="ping-localhost,ping-public-repo,clean,update,build,deploy"
         description="Clean, update, build, and deploy all packages (assumes 'setup' has already been run)"/>
 
@@ -32,13 +34,13 @@
     <target name="clone-private-repos" if="${remotes.include-private}"
         description="Clone private packages">
         <echo message="Cloning private packages into ${repos}..."/>
-        <foreach-js property="remotes.private" target="git.clone"/>
+        <foreach list="${remotes.private}" delimiter="," parallel="true" target="git.clone" param="remote"/>
     </target>
 
     <target name="clone-public-repos">
         <echo message="Cloning required packages into ${repos}..."
             description="Clone public packages"/>
-        <foreach-js property="remotes" target="git.clone"/>
+        <foreach list="${remotes}" delimiter="," parallel="true" target="git.clone" param="remote"/>
     </target>
 
     <target name="setup" depends="prepare,mvn-copy-dependencies,upgrade-local-build-properties,clone-public-repos,clone-private-repos"
@@ -460,32 +462,13 @@
         ]]>
     </scriptdef>
 
-    <scriptdef name="foreach-js" language="javascript">
-        <attribute name="target"/>
-        <attribute name="property"/>
-        <![CDATA[
-            var input = project.getProperty(attributes.get("property"));
-            var items = input.split(/\s*,\s*/);
-            for (i=0; i < items.length; i++) {
-              // create and use a Task via Ant API
-              antc = project.createTask("antcall");
-              var prop = antc.createParam();
-              prop.setName("item");
-              prop.setValue(items[i]);
-
-              antc.setTarget(attributes.get("target"));
-              antc.perform();
-            }
-        ]]>
-    </scriptdef>
-
     <target name="git.clone">
-        <echo message="Cloning ${item}..."/>
+        <echo message="Cloning ${remote}..."/>
         <exec executable="${git}" outputproperty="git.output" dir="${repos}">
             <arg line="clone"/>
             <arg line="--depth"/>
             <arg line="1"/>
-            <arg line="${item}"/>
+            <arg line="${remote}"/>
         </exec>
         <echo message="${git.output}"/>
     </target>

--- a/build.xml
+++ b/build.xml
@@ -113,12 +113,35 @@
         <echo message="-------------------------------------"/>
         <echo message="Pulling updates for all repositories"/>
         <echo message="-------------------------------------"/>
-        <iterate target="git.pull"/>
+
+        <antcall target="update-public-repos"/>
+        <antcall target="update-private-repos"/>
+    </target>
+
+    <target name="update-private-repos" if="${git.private.include}"
+        description="Update private packages">
+        <echo message="Cloning private packages into ${repos}..."/>
+        <foreach list="${git.private.repo-names}" delimiter="," parallel="false" target="git.pull-path" param="repo-name"/>
+    </target>
+
+    <target name="update-public-repos">
+        <echo message="Updating required packages into ${repos}..."
+            description="Update public packages"/>
+        <foreach list="${git.public.repo-names}" delimiter="," parallel="false" target="git.pull-path" param="repo-name"/>
+
+        <!-- TODO(AR) these should likely move to HistoryAtState -->
+        <foreach list="${git.joewiz.repo-names}" delimiter="," parallel="false" target="git.pull-path" param="repo-name"/>
+    </target>
+
+    <target name="git.pull-path">
+        <antcall target="git.pull">
+            <param name="local-repo-path" value="${repos}/${repo-name}"/>
+        </antcall>
     </target>
 
     <target name="update-one">
         <antcall target="git.pull">
-            <param name="dir" value="${repos}/${repo-name}"/>
+            <param name="local-repo-path" value="${repos}/${repo-name}"/>
         </antcall>
     </target>
 
@@ -418,13 +441,13 @@
     </target>
 
     <target name="git.pull">
-        <echo message="Updating ${dir}..."/>
-        <delete file="${dir}/package-lock.json"/>
-        <exec executable="${git}" dir="${dir}">
+        <echo message="Updating ${local-repo-path}..."/>
+        <delete file="${local-repo-path}/package-lock.json"/>
+        <exec executable="${git}" dir="${local-repo-path}" failonerror="true">
             <arg line="pull"/>
             <arg line="--recurse-submodules"/>
         </exec>
-        <exec executable="${git}" dir="${dir}">
+        <exec executable="${git}" dir="${local-repo-path}" failonerror="true">
             <arg line="submodule"/>
             <arg line="update"/>
             <arg line="--recursive"/>
@@ -690,7 +713,7 @@
         <propertyregex property="repo-name" input="${file-path.unix}"
             regexp=".*/hsg-project/${repos}/([^/]+)" select="\1" defaultvalue="Error" override="true"/>
         <antcall target="git.pull">
-            <param name="dir" value="${repos}/${repo-name}"/>
+            <param name="local-repo-path" value="${repos}/${repo-name}"/>
         </antcall>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -517,8 +517,6 @@
         <echo message="Cloning ${origin}..."/>
         <exec executable="${git}" outputproperty="git.output" dir="${repos}" failonerror="true">
             <arg line="clone"/>
-            <arg line="--depth"/>
-            <arg line="1"/>
             <arg line="${origin}"/>
             <arg line="${local-repo-name}"/>
         </exec>

--- a/build.xml
+++ b/build.xml
@@ -34,7 +34,7 @@
     <target name="clone-private-repos" if="${git.private.include}"
         description="Clone private packages">
         <echo message="Cloning private packages into ${repos}..."/>
-        <foreach list="${git.private.repo-names}" delimiter="," parallel="true" target="git.clone.private" param="repo-name"/>
+        <foreach list="${git.private.repo-names}" delimiter="," parallel="false" target="git.clone.private" param="repo-name"/>
     </target>
 
     <target name="git.clone.private">
@@ -48,7 +48,7 @@
     <target name="clone-public-repos">
         <echo message="Cloning required packages into ${repos}..."
             description="Clone public packages"/>
-        <foreach list="${git.public.repo-names}" delimiter="," parallel="true" target="git.clone.public" param="repo-name"/>
+        <foreach list="${git.public.repo-names}" delimiter="," parallel="false" target="git.clone.public" param="repo-name"/>
     </target>
 
     <target name="git.clone.public">

--- a/build.xml
+++ b/build.xml
@@ -799,28 +799,28 @@
 
     <target name="ping-localhost">
         <condition property="exist-running">
-            <http requestmethod="HEAD" url="http://localhost:8080/exist/status"/>
+            <http requestmethod="HEAD" url="http://localhost:8080/exist" expected="200"/>
         </condition>
         <fail unless="${exist-running}" message="eXist is not running. Please start eXist and try again."/>
     </target>
 
     <target name="ping-production">
         <condition property="exist-running">
-            <http requestmethod="GET" url="${production.instance.http}/test" />
+            <http requestmethod="GET" url="${production.instance.http}/test" expected="200"/>
         </condition>
         <fail unless="${exist-running}" message="The production server cannot be reached. Please confirm you are connected to the internet and try again."/>
     </target>
 
     <target name="ping-dev-server">
         <condition property="exist-running">
-            <http requestmethod="GET" url="${development.instance.http}" />
+            <http requestmethod="GET" url="${development.instance.http}" expected="200"/>
         </condition>
         <fail unless="${exist-running}" message="The development server cannot be reached. Please confirm you are connected to the internet and try again."/>
     </target>
     
     <target name="ping-public-repo">
         <condition property="public-repo-accessible">
-            <http requestmethod="HEAD" url="${eXist.public-repo.lookup}?abbrev=functx" followRedirects="true"/>
+            <http requestmethod="HEAD" url="${eXist.public-repo.lookup}?abbrev=functx" followRedirects="true" expected="200"/>
         </condition>
         <fail unless="${public-repo-accessible}" message="The package repository at ${eXist.public-repo} cannot be reached. Please confirm you are connected to the internet and try again."/>
     </target>
@@ -830,7 +830,7 @@
     <!-- =================================================================== -->
     <target name="wipe-exist-data" description="Wipe eXist data">
         <condition property="exist-running">
-            <http requestmethod="GET" url="http://localhost:8080/exist/status"/>
+            <http requestmethod="GET" url="http://localhost:8080/exist" expected="200"/>
         </condition>
         <fail if="${exist-running}"
             message="eXist is still running. Please shut down eXist and try again."/>

--- a/build.xml
+++ b/build.xml
@@ -841,21 +841,7 @@
         <echo message="-------------------------"/>
         <echo message="Wiping eXist data"/>
         <echo message="-------------------------"/>
-        <delete dir="${eXist.data}/backup"/>
-        <delete dir="${eXist.data}/blob"/>
-        <delete dir="${eXist.data}/expathrepo"/>
-        <delete dir="${eXist.data}/fs"/>
-        <delete dir="${eXist.data}/fs.journal"/>
-        <delete dir="${eXist.data}/journal"/>
-        <delete dir="${eXist.data}/lucene"/>
-        <delete dir="${eXist.data}/metadata"/>
-        <delete dir="${eXist.data}/range"/>
-        <delete dir="${eXist.data}/sanity"/>
-        <delete>
-            <fileset dir="${eXist.data}"
-                includes="*.dbx,*.log,*.lck,spatial_index.*,counters,restxq.registry"
-                excludes=".DO_NOT_DELETE"/>
-        </delete>
+        <delete dir="${eXist.data}"/>
     </target>
 
     <target name="wipe-exist-data-with-confirmation" description="Wipe eXist data">

--- a/build.xml
+++ b/build.xml
@@ -49,6 +49,9 @@
         <echo message="Cloning required packages into ${repos}..."
             description="Clone public packages"/>
         <foreach list="${git.public.repo-names}" delimiter="," parallel="false" target="git.clone.public" param="repo-name"/>
+
+        <!-- TODO(AR) these should likely move to HistoryAtState -->
+        <foreach list="${git.joewiz.repo-names}" delimiter="," parallel="false" target="git.clone.joewiz" param="repo-name"/>
     </target>
 
     <target name="git.clone.public">
@@ -56,6 +59,15 @@
             <param name="local-repo-name" value="${repo-name}"/>
             <param name="origin" value="${git.public.remotes.origin.org}/${repo-name}.git"/>
             <param name="upstream" value="${git.public.remotes.upstream.org}/${repo-name}.git"/>
+        </antcall>
+    </target>
+
+    <!-- TODO(AR) these should likely move to HistoryAtState -->
+    <target name="git.clone.joewiz">
+        <antcall target="git.clone">
+            <param name="local-repo-name" value="${repo-name}"/>
+            <param name="origin" value="${git.joewiz.remotes.origin.org}/${repo-name}.git"/>
+            <param name="upstream" value="${git.joewiz.remotes.upstream.org}/${repo-name}.git"/>
         </antcall>
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -888,7 +888,7 @@
     </condition>
 
     <target name="upgrade-local-build-properties"
-        description="Upgrade local.build.properties file to latest build.properties while preserving passwords" depends="create-new-local-build-properties">
+        description="Upgrade local.build.properties file to latest build.properties while preserving passwords" depends="check-local-build-properties">
         <echo message="------------------------------------------------------------"/>
         <echo message="Upgrading local.build.properties file (preserving passwords)"/>
         <echo message="------------------------------------------------------------"/>

--- a/build.xml
+++ b/build.xml
@@ -487,12 +487,15 @@
             <arg line="${origin}"/>
             <arg line="${local-repo-name}"/>
         </exec>
+        <echo message="${git.output}"/>
 
         <condition property="set-upstream">
             <not>
                 <equals arg1="${origin}" arg2="${upstream}"/>
             </not>
         </condition>
+
+        <echo if:true="${set-upstream}" message="Configuring upstream: ${upstream}..."/>
 
         <exec if:true="${set-upstream}" executable="${git}" dir="${repos}/${local-repo-name}" failonerror="true">
             <arg line="remote"/>
@@ -506,7 +509,6 @@
             <arg line="upstream"/>
         </exec>
 
-        <echo message="${git.output}"/>
     </target>
 
     <target name="test">

--- a/build/build.properties
+++ b/build/build.properties
@@ -58,8 +58,17 @@ git.public.repo-names=hsg-shell,\
     tumblr,\
     twitter,\
     visits,\
-    wwdai,\
-    hsg-test,\
+    wwdai
+
+# TODO(AR) these should likely move to HistoryAtState
+# If the `upstream` and `origin` are different then both will
+# be configured, otherwise only the origin will be configured.
+# If you work with a fork, you can set that as the `origin`.
+git.joewiz.remotes.upstream.org=https://github.com/joewiz
+git.joewiz.remotes.origin.org=https://github.com/joewiz
+
+# TODO(AR) these should likely move to HistoryAtState
+git.joewiz.repo-names=hsg-test,\
     gsh,\
     s3
 

--- a/build/build.properties
+++ b/build/build.properties
@@ -5,8 +5,8 @@
 
 # path to executables
 git=git
-github=/usr/local/bin/github
-mvn=/usr/local/bin/mvn
+github=github
+mvn=mvn
 vscode=/usr/local/bin/code
 
 # eXist-related paths

--- a/build/build.properties
+++ b/build/build.properties
@@ -32,34 +32,48 @@ development.instance.uri=xmldb\:exist\://1861.hsg/exist/xmlrpc
 development.instance.user=admin
 development.instance.password=
 
-remotes=https://github.com/HistoryAtState/hsg-shell.git,\
-    https://github.com/HistoryAtState/administrative-timeline.git,\
-    https://github.com/HistoryAtState/carousel.git,\
-    https://github.com/HistoryAtState/conferences.git,\
-    https://github.com/HistoryAtState/frus.git,\
-    https://github.com/HistoryAtState/frus-not-yet-reviewed.git,\
-    https://github.com/HistoryAtState/frus-history.git,\
-    https://github.com/HistoryAtState/hac.git,\
-    https://github.com/HistoryAtState/milestones.git,\
-    https://github.com/HistoryAtState/other-publications.git,\
-    https://github.com/HistoryAtState/people.git,\
-    https://github.com/HistoryAtState/pocom.git,\
-    https://github.com/HistoryAtState/rdcr.git,\
-    https://github.com/HistoryAtState/release.git,\
-    https://github.com/HistoryAtState/tags.git,\
-    https://github.com/HistoryAtState/terms.git,\
-    https://github.com/HistoryAtState/travels.git,\
-    https://github.com/HistoryAtState/tumblr.git,\
-    https://github.com/HistoryAtState/twitter.git,\
-    https://github.com/HistoryAtState/visits.git,\
-    https://github.com/HistoryAtState/wwdai.git,\
-    https://github.com/joewiz/hsg-test.git,\
-    https://github.com/joewiz/gsh.git,\
-    https://github.com/joewiz/s3.git
+# If the `upstream` and `origin` are different then both will
+# be configured, otherwise only the origin will be configured.
+# If you work with a fork, you can set that as the `origin`.
+git.public.remotes.upstream.org=https://github.com/HistoryAtState
+git.public.remotes.origin.org=https://github.com/HistoryAtState
 
-remotes.include-private=false
-remotes.private=https://gitlab.com/HistoryAtState/guides.git,\
-    https://gitlab.com/HistoryAtState/guides-data.git,\
-    https://gitlab.com/HistoryAtState/hsa.git,\
-    https://gitlab.com/HistoryAtState/hsa-data.git,\
-    https://gitlab.com/HistoryAtState/hsg-staging.git
+git.public.repo-names=hsg-shell,\
+    administrative-timeline,\
+    carousel,\
+    conferences,\
+    frus,\
+    frus-not-yet-reviewed,\
+    frus-history,\
+    hac,\
+    milestones,\
+    other-publications,\
+    people,\
+    pocom,\
+    rdcr,\
+    release,\
+    tags,\
+    terms,\
+    travels,\
+    tumblr,\
+    twitter,\
+    visits,\
+    wwdai,\
+    hsg-test,\
+    gsh,\
+    s3
+
+# true to also include the private repos, false otherwise
+git.private.include=false
+
+# If the `upstream` and `origin` are different then both will
+# be configured, otherwise only the origin will be configured.
+# If you work with a fork, you can set that as the `origin`.
+git.private.remotes.upstream.org=https://gitlab.com/HistoryAtState
+git.private.remotes.origin.org=https://gitlab.com/HistoryAtState
+
+git.private.repo-names=guides,\
+    guides-data,\
+    hsa,\
+    hsa-data,\
+    hsg-staging

--- a/build/build.properties
+++ b/build/build.properties
@@ -10,7 +10,7 @@ mvn=mvn
 vscode=/usr/local/bin/code
 
 # eXist-related paths
-eXist.data=../exist/webapp/WEB-INF/data
+eXist.data=../exist/data
 eXist.home=../exist
 eXist.public-repo=https\://public-repo.ci.history.state.gov/exist/apps/public-repo
 eXist.public-repo.lookup=https\://public-repo.ci.history.state.gov/exist/apps/public-repo/find


### PR DESCRIPTION
1. This avoids your `local.build.properties` being erased when running `setup` more than one
2. Assumes that `git`, `github` and `mvn` are all present on the PATH. This is the case for macOS packages installed via Homebrew, and also for sensibly configured Linux systems.  Therefore this now works "out-of-the-box" by default on more systems.
3. Adds some fixes for eXist-db 5 vs 4.
4. It uses ant-contrib tasks in favour of embedded JavaScript
5. It adds a facility for working with forks of the repositories, can be configured via `local.build.properties`
6. Stops the build if critical exec steps fail
7. General cleanup